### PR TITLE
Add a new Calendar advanced service example.

### DIFF
--- a/advanced/calendar.gs
+++ b/advanced/calendar.gs
@@ -137,9 +137,9 @@ function parseDate(string) {
  * since the last sync. If the sync token is missing or invalid, log all
  * events from up to a month ago (a full sync).
  *
- * @param calendarId The ID of the calender to retrieve events from.
- * @param fullSync If true, throw out any existing sync token and perform a full sync;
- *        if false, use the existing sync token if possible.
+ * @param {string} calendarId The ID of the calender to retrieve events from.
+ * @param {boolean} fullSync If true, throw out any existing sync token and
+ *        perform a full sync; if false, use the existing sync token if possible.
  */
 function logSyncedEvents(calendarId, fullSync) {
   var properties = PropertiesService.getUserProperties();

--- a/advanced/calendar.gs
+++ b/advanced/calendar.gs
@@ -152,7 +152,7 @@ function logSyncedEvents(calendarId, fullSync) {
     options['syncToken'] = syncToken;
   } else {
     // Sync events up to thirty days in the past.
-    options['timeMin'] = getRelativeDate(-30,0).toISOString();
+    options['timeMin'] = getRelativeDate(-30, 0).toISOString();
   }
 
   // Retrieve events, one page at a time.
@@ -169,7 +169,7 @@ function logSyncedEvents(calendarId, fullSync) {
         logSyncedEvents(calendarId, true);
         return;
       } else {
-        throw e.message;
+        throw new Error(e.message);
       }
     }
     

--- a/advanced/calendar.gs
+++ b/advanced/calendar.gs
@@ -129,3 +129,72 @@ function parseDate(string) {
   return new Date(parts.join(' '));
 }
 // [END listNext10Events]
+
+// [START logSyncedEvents]
+
+/**
+ * Retrieve and log events from the given calendar that have been modified
+ * since the last sync. If the sync token is missing or invalid, log all
+ * events from up to a month ago (a full sync).
+ *
+ * @param calendarId The ID of the calender to retrieve events from.
+ * @param fullSync If true, throw out any existing sync token and perform a full sync;
+ *        if false, use the existing sync token if possible.
+ */
+function logSyncedEvents(calendarId, fullSync) {
+  var properties = PropertiesService.getUserProperties();
+  var pageToken;
+  var options = {
+    maxResults: 100
+  };
+  var syncToken = properties.getProperty('syncToken');
+  if (syncToken && !fullSync) {
+    options['syncToken'] = syncToken;
+  } else {
+    // Sync events up to thirty days in the past.
+    options['timeMin'] = getRelativeDate(-30,0).toISOString();
+  }
+
+  // Retrieve events, one page at a time.
+  var events;
+  do {
+    try {
+      options['pageToken'] = pageToken;
+      events = Calendar.Events.list(calendarId, options);
+    } catch (e) {
+      // Check to see if the sync token was invalidated by the server;
+      // if so, perform a full sync instead.
+      if (e.message === "Sync token is no longer valid, a full sync is required." ) {
+        properties.deleteProperty('syncToken');
+        logSyncedEvents(calendarId, true);
+        return;
+      } else {
+        throw e.message;
+      }
+    }
+    
+    if (events.items && events.items.length > 0) {
+      for(var i = 0; i < events.items.length; i++) {
+         var event = events.items[i];
+         if (event.status === 'cancelled') {
+           console.log('Event id %s was cancelled.', event.id);
+         } else if (event.start.date) {
+           // All-day event.
+           var start = parseDate(event.start.date);
+           console.log('%s (%s)', event.summary, start.toLocaleDateString());
+         } else {
+           var start = parseDate(event.start.dateTime);
+           console.log('%s (%s)', event.summary, start.toLocaleString());
+         }
+      }
+    } else {
+      console.log('No events found.');
+    }
+
+    pageToken = events.nextPageToken;
+  } while (pageToken);
+  
+  properties.setProperty('syncToken', events.nextSyncToken);
+}
+
+// [END logSyncedEvents]

--- a/advanced/calendar.gs
+++ b/advanced/calendar.gs
@@ -142,28 +142,28 @@ function parseDate(string) {
  */
 function logSyncedEvents(calendarId, fullSync) {
   var properties = PropertiesService.getUserProperties();
-  var pageToken;
   var options = {
     maxResults: 100
   };
   var syncToken = properties.getProperty('syncToken');
   if (syncToken && !fullSync) {
-    options['syncToken'] = syncToken;
+    options.syncToken = syncToken;
   } else {
     // Sync events up to thirty days in the past.
-    options['timeMin'] = getRelativeDate(-30, 0).toISOString();
+    options.timeMin = getRelativeDate(-30, 0).toISOString();
   }
 
-  // Retrieve events, one page at a time.
+  // Retrieve events one page at a time.
   var events;
+  var pageToken;
   do {
     try {
-      options['pageToken'] = pageToken;
+      options.pageToken = pageToken;
       events = Calendar.Events.list(calendarId, options);
     } catch (e) {
       // Check to see if the sync token was invalidated by the server;
       // if so, perform a full sync instead.
-      if (e.message === "Sync token is no longer valid, a full sync is required." ) {
+      if (e.message === "Sync token is no longer valid, a full sync is required.") {
         properties.deleteProperty('syncToken');
         logSyncedEvents(calendarId, true);
         return;
@@ -173,7 +173,7 @@ function logSyncedEvents(calendarId, fullSync) {
     }
     
     if (events.items && events.items.length > 0) {
-      for(var i = 0; i < events.items.length; i++) {
+      for (var i = 0; i < events.items.length; i++) {
          var event = events.items[i];
          if (event.status === 'cancelled') {
            console.log('Event id %s was cancelled.', event.id);
@@ -182,6 +182,7 @@ function logSyncedEvents(calendarId, fullSync) {
            var start = parseDate(event.start.date);
            console.log('%s (%s)', event.summary, start.toLocaleDateString());
          } else {
+	   // Events that don't last all day; they have defined start times.
            var start = parseDate(event.start.dateTime);
            console.log('%s (%s)', event.summary, start.toLocaleString());
          }

--- a/advanced/calendar.gs
+++ b/advanced/calendar.gs
@@ -131,7 +131,6 @@ function parseDate(string) {
 // [END listNext10Events]
 
 // [START logSyncedEvents]
-
 /**
  * Retrieve and log events from the given calendar that have been modified
  * since the last sync. If the sync token is missing or invalid, log all
@@ -196,5 +195,4 @@ function logSyncedEvents(calendarId, fullSync) {
   
   properties.setProperty('syncToken', events.nextSyncToken);
 }
-
 // [END logSyncedEvents]

--- a/advanced/calendar.gs
+++ b/advanced/calendar.gs
@@ -182,7 +182,7 @@ function logSyncedEvents(calendarId, fullSync) {
            var start = parseDate(event.start.date);
            console.log('%s (%s)', event.summary, start.toLocaleDateString());
          } else {
-	   // Events that don't last all day; they have defined start times.
+           // Events that don't last all day; they have defined start times.
            var start = parseDate(event.start.dateTime);
            console.log('%s (%s)', event.summary, start.toLocaleString());
          }


### PR DESCRIPTION
Adds a sample to the Calendar Advanced Service set. The sample covers using sync tokens when retrieving events, similar to the Calendar API code listed here:

https://developers.google.com/calendar/v3/sync#sample_code