### PR TITLE
replace deprecated getTimeZone

### DIFF
--- a/advanced/youtubeAnalytics.gs
+++ b/advanced/youtubeAnalytics.gs
@@ -74,7 +74,7 @@ function createReport() {
  * @return {string} The formatted date.
  */
 function formatDateString(date) {
-  return Utilities.formatDate(date, Session.getTimeZone(), 'yyyy-MM-dd');
+  return Utilities.formatDate(date, Session.getScriptTimeZone(), 'yyyy-MM-dd');
 }
 
 /**


### PR DESCRIPTION
`getTimeZone` is [deprecated](https://developers.google.com/apps-script/reference/base/session#getTimeZone()). replace with `getScriptTimeZone`.