### PR TITLE
Add links to Apps Script codelabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Codelab tutorials combine explanation, working best-practice example code, and c
 - [Apps Script Intro](http://g.co/codelabs/apps-script-intro)
 - [Apps Script CLI – clasp](http://g.co/codelabs/clasp)
 - [BigQuery + Sheets + Slides](http://g.co/codelabs/bigquery-sheets-slides)
-- [Docs Add-on + GCP NLP API](http://g.co/codelabs/nlp-docs)
+- [Docs Add-on + Cloud Natural Language API](http://g.co/codelabs/nlp-docs)
 - [Gmail Add-ons](http://g.co/codelabs/gmail-add-ons)
 - [Hangouts Chat Bots](http://g.co/codelabs/chat-apps-script)
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ width="96px"/>
 - Call an Apps Script function such as `onOpen`, `onEdit`, or `onInstall` in an add-on
 - Create a [time-driven trigger](https://developers.google.com/apps-script/guides/triggers/installable#time_driven_triggers)
 
+## Codelabs
+
+Codelab tutorials combine explanation, working best-practice example code, and code exercises to help engineers get up to speed with key Google technologies. Here's a list of Apps Script codelabs:
+
+- [Apps Script Intro](http://g.co/codelabs/apps-script-intro)
+- [Apps Script CLI – clasp](http://g.co/codelabs/clasp)
+- [BigQuery + Sheets + Slides](http://g.co/codelabs/bigquery-sheets-slides)
+- [Docs Add-on + GCP NLP API](http://g.co/codelabs/nlp-docs)
+- [Gmail Add-ons](http://g.co/codelabs/gmail-add-ons)
+- [Hangouts Chat Bots](http://g.co/codelabs/chat-apps-script)
+
 ## Clone using the `clasp` command line tool
 
 Learn how to clone, pull, and push Apps Script projects on the command line

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ width="96px"/>
 
 ## Codelabs
 
-Codelab tutorials combine explanation, working best-practice example code, and code exercises to help engineers get up to speed with key Google technologies. Here's a list of Apps Script codelabs:
+Codelab tutorials combine detailed explanation, coding exercises, and documented best practices to help engineers get up to speed with key Google technologies. Here's a list of Apps Script codelabs:
 
 - [Apps Script Intro](http://g.co/codelabs/apps-script-intro)
 - [Apps Script CLI – clasp](http://g.co/codelabs/clasp)


### PR DESCRIPTION
This PR adds a section for Apps Script codelabs.
By adding these links, we can better advertise this repo as a training resource for Apps Script learners.