### PR TITLE
fix: slides_create_image URL

### DIFF
--- a/slides/api/Snippets.gs
+++ b/slides/api/Snippets.gs
@@ -120,14 +120,16 @@ Snippets.prototype.createTextboxWithText = function(presentationId, pageId) {
 
 Snippets.prototype.createImage = function(presentationId, pageId) {
   // [START slides_create_image]
-  // Temporarily upload a local image file to Drive, in order to obtain a
-  // URL for the image. Alternatively, you can provide the Slides service
-  // a URL of an already hosted image.
+  // Temporarily upload a local image file to Drive, in order to obtain a URL
+  // for the image. Alternatively, you can provide the Slides service a URL of
+  // an already hosted image.
   //
-  // We will use an existing image under the variable: IMAGE_URL.
+  // We will use an existing image under the variable: imageUrl.
+  //
+  // Create a new image, using the supplied object ID, with content downloaded from imageUrl.
   var requests = [];
   var imageId = 'MyImage_01';
-  var IMAGE_URL = 'https://www.google.com/images/branding/googlelogo/2x/' + 
+  var imageUrl = 'https://www.google.com/images/branding/googlelogo/2x/' +
       'googlelogo_color_272x92dp.png';
   var emu4M = {
     magnitude: 4000000,
@@ -136,7 +138,7 @@ Snippets.prototype.createImage = function(presentationId, pageId) {
   requests.push({
     createImage: {
       objectId: imageId,
-      url: IMAGE_URL,
+      url: imageUrl,
       elementProperties: {
         pageObjectId: pageId,
         size: {

--- a/slides/api/Snippets.gs
+++ b/slides/api/Snippets.gs
@@ -120,12 +120,6 @@ Snippets.prototype.createTextboxWithText = function(presentationId, pageId) {
 
 Snippets.prototype.createImage = function(presentationId, pageId) {
   // [START slides_create_image]
-  // Temporarily upload a local image file to Drive, in order to obtain a URL
-  // for the image. Alternatively, you can provide the Slides service a URL of
-  // an already hosted image.
-  //
-  // We will use an existing image under the variable: imageUrl.
-  //
   // Create a new image, using the supplied object ID, with content downloaded from imageUrl.
   var requests = [];
   var imageId = 'MyImage_01';

--- a/slides/api/Snippets.gs
+++ b/slides/api/Snippets.gs
@@ -120,13 +120,11 @@ Snippets.prototype.createTextboxWithText = function(presentationId, pageId) {
 
 Snippets.prototype.createImage = function(presentationId, pageId) {
   // [START slides_create_image]
-  // Temporarily upload a local image file to Drive, in order to obtain a URL
-  // for the image. Alternatively, you can provide the Slides service a URL of
-  // an already hosted image.
+  // Temporarily upload a local image file to Drive, in order to obtain a
+  // URL for the image. Alternatively, you can provide the Slides service
+  // a URL of an already hosted image.
   //
-  // We will use an existing image under the variable: imageUrl.
-  //
-  // Create a new image, using the supplied object ID, with content downloaded from imageUrl.
+  // We will use an existing image under the variable: IMAGE_URL.
   var requests = [];
   var imageId = 'MyImage_01';
   var IMAGE_URL = 'https://www.google.com/images/branding/googlelogo/2x/' + 

--- a/slides/api/Snippets.gs
+++ b/slides/api/Snippets.gs
@@ -119,14 +119,18 @@ Snippets.prototype.createTextboxWithText = function(presentationId, pageId) {
 };
 
 Snippets.prototype.createImage = function(presentationId, pageId) {
-  var imageFileId = '0B2P_aO_vjnJ4aERnX2ZzbUtMZXc';
   // [START slides_create_image]
-  // Add a new image to the presentation page. The image is assumed to exist in
-  // the user's Drive, and have 'imageFileId' as its file ID.
+  // Temporarily upload a local image file to Drive, in order to obtain a URL
+  // for the image. Alternatively, you can provide the Slides service a URL of
+  // an already hosted image.
+  //
+  // We will use an existing image under the variable: imageUrl.
+  //
+  // Create a new image, using the supplied object ID, with content downloaded from imageUrl.
   var requests = [];
   var imageId = 'MyImage_01';
-  var imageUrl = DriveApp.getFileById(imageFileId).getDownloadUrl() + '&access_token=' +
-      ScriptApp.getOAuthToken();
+  var IMAGE_URL = 'https://www.google.com/images/branding/googlelogo/2x/' + 
+      'googlelogo_color_272x92dp.png';
   var emu4M = {
     magnitude: 4000000,
     unit: 'EMU'
@@ -134,7 +138,7 @@ Snippets.prototype.createImage = function(presentationId, pageId) {
   requests.push({
     createImage: {
       objectId: imageId,
-      url: imageUrl,
+      url: IMAGE_URL,
       elementProperties: {
         pageObjectId: pageId,
         size: {


### PR DESCRIPTION
Removes discouraged `getOAuthToken` method from  `slides_create_image` snippet.

I ran the test for this region tag successfully:

![Screen Shot 2019-08-06 at 18 08 22](https://user-images.githubusercontent.com/744973/62587110-37e5c400-b875-11e9-803e-c1979773c400.png)

Comment is copied from other samples:
https://devsite.googleplex.com/slides/how-tos/add-image