### PR TITLE
Fix filename casing in notifications quickstart

### DIFF
--- a/forms/notifications/notification.gs
+++ b/forms/notifications/notification.gs
@@ -220,7 +220,7 @@ function sendReauthorizationRequest() {
   if (lastAuthEmailDate != today) {
     if (MailApp.getRemainingDailyQuota() > 0) {
       var template =
-          HtmlService.createTemplateFromFile('AuthorizationEmail');
+          HtmlService.createTemplateFromFile('authorizationEmail');
       template.url = authInfo.getAuthorizationUrl();
       template.notice = NOTICE;
       var message = template.evaluate();
@@ -255,7 +255,7 @@ function sendCreatorNotification() {
     var addresses = settings.getProperty('creatorEmail').split(',');
     if (MailApp.getRemainingDailyQuota() > addresses.length) {
       var template =
-          HtmlService.createTemplateFromFile('CreatorNotification');
+          HtmlService.createTemplateFromFile('creatorNotification');
       template.sheet =
           DriveApp.getFileById(form.getDestinationId()).getUrl();
       template.summary = form.getSummaryUrl();
@@ -290,7 +290,7 @@ function sendRespondentNotification(response) {
       .getResponse();
   if (respondentEmail) {
     var template =
-        HtmlService.createTemplateFromFile('RespondentNotification');
+        HtmlService.createTemplateFromFile('respondentNotification');
     template.paragraphs = settings.getProperty('responseText').split('\n');
     template.notice = NOTICE;
     var message = template.evaluate();

--- a/forms/notifications/notification.gs
+++ b/forms/notifications/notification.gs
@@ -75,7 +75,7 @@ function onInstall(e) {
  * configuring the notifications this add-on will produce.
  */
 function showSidebar() {
-  var ui = HtmlService.createHtmlOutputFromFile('Sidebar')
+  var ui = HtmlService.createHtmlOutputFromFile('sidebar')
       .setTitle('Form Notifications');
   FormApp.getUi().showSidebar(ui);
 }
@@ -85,7 +85,7 @@ function showSidebar() {
  * this add-on.
  */
 function showAbout() {
-  var ui = HtmlService.createHtmlOutputFromFile('About')
+  var ui = HtmlService.createHtmlOutputFromFile('about')
       .setWidth(420)
       .setHeight(270);
   FormApp.getUi().showModalDialog(ui, 'About Form Notifications');


### PR DESCRIPTION
see b/152073675

The `createTemplateFromFile` ones were just incorrect based on the filenames here in this repo. (Though the markdown referred to them in title case)

The `createHtmlOutputFromFile` changes, also need the markdown CL to land.