### PR TITLE
notification quickstart: remove destination sheet link

### DIFF
--- a/forms/notifications/creatorNotification.html
+++ b/forms/notifications/creatorNotification.html
@@ -3,7 +3,6 @@
 titled <a href="<?= formUrl?>"><b><?= title ?></b></a> has received
 <?= responses ?> responses so far.</p>
 
-<p><a href="<?= sheet ?>">Response sheet</a></p>
 <p><a href="<?= summary ?>">Summary of form responses</a></p>
 
 <p>You are receiving this email because an editor of this form configured

--- a/forms/notifications/notification.gs
+++ b/forms/notifications/notification.gs
@@ -256,8 +256,6 @@ function sendCreatorNotification() {
     if (MailApp.getRemainingDailyQuota() > addresses.length) {
       var template =
           HtmlService.createTemplateFromFile('CreatorNotification');
-      template.sheet =
-          DriveApp.getFileById(form.getDestinationId()).getUrl();
       template.summary = form.getSummaryUrl();
       template.responses = form.getResponses().length;
       template.title = form.getTitle();


### PR DESCRIPTION
Forms nowadays do not have a destination, by default.

So this script ends up failing silently (to the user).  In the error logs you'll see `Exception: The form currently has no response destination`

![image](https://user-images.githubusercontent.com/39191/77212411-38f5f980-6ac4-11ea-98d2-eb14d597d680.png)

Since there's a link to the form summary already, I think the UX is still pretty fine.

-------

The quickstart will be functional again once this PR, #144 and the docs CL are merged. \o/